### PR TITLE
Segmentar listado equlibrado bugfix

### DIFF
--- a/manzanas_independientes/segmentar_equilibrado_ffrr.sql
+++ b/manzanas_independientes/segmentar_equilibrado_ffrr.sql
@@ -103,7 +103,7 @@ from (segmentos_id
 join segmento_id_en_mza
 using (prov, dpto, codloc, frac, radio, mza, sgm_mza)) j
 where listado_id = j.id
-into resultados';
+';
 
 get diagnostics n = row_count;
 

--- a/manzanas_independientes/segmentar_listado_equilibrado.sql
+++ b/manzanas_independientes/segmentar_listado_equilibrado.sql
@@ -21,8 +21,10 @@ indec.segmentar_listado_equilibrado(esquema text, query text, orden_recorrido te
 as $function$
 declare
 n int;
+consulta text;
 begin
-execute '
+RAISE NOTICE 'Segmentando listado equilibrado %',esquema;
+consulta := '
 with
 parametros as (
     select ' || deseado || '::float as deseado),
@@ -31,7 +33,7 @@ listado_sin_nulos as (
     select id, prov, dpto, codloc, frac, radio, mza, lado, 
     CASE WHEN trim(nrocatastr) in ('''',null,''S/N'',''S N'') THEN orden_reco else nrocatastr END  nrocatastr ,
     coalesce(sector,'''') sector, coalesce(edificio,'''') edificio, coalesce(entrada,'''') entrada,
-     piso, coalesce(CASE WHEN orden_reco='''' THEN NULL ELSE orden_reco END,''0'')::integer orden_reco
+    coalesce(piso,'''') piso, coalesce(CASE WHEN orden_reco='''' THEN NULL ELSE orden_reco END,''0'')::integer orden_reco
     from listado
     ),
 
@@ -82,7 +84,7 @@ segmento_id_en_listado as (
   select id, prov, dpto, codloc, frac, radio, mza, lado, nrocatastr, sector, edificio, entrada, piso, orden_reco::integer,
     sgm_listado
   from listado_sin_nulos
-  join asignacion_segmentos_pisos_enteros
+full  join asignacion_segmentos_pisos_enteros
   using (prov, dpto, codloc, frac, radio, mza, lado, nrocatastr, sector, edificio, entrada, piso)
   ),
   
@@ -104,7 +106,8 @@ using (prov, dpto, codloc, frac, radio, sgm_listado)) j
 where listado_id = j.id
 
 ';
-
+execute consulta;
+RAISE NOTICE 'Consulta %',consulta;
 get diagnostics n = row_count;
 return n;
 


### PR DESCRIPTION
Busca arreglar la resegmentación de los segmentos excedidos usando el orden_reco cuando no viene numero catastral para ese fin.